### PR TITLE
added tentative courses page

### DIFF
--- a/data/headerNavLinks.js
+++ b/data/headerNavLinks.js
@@ -1,7 +1,7 @@
 const headerNavLinks = [
   { href: '/blog', title: 'All' },
-  { href: '/tags/homework', title: 'Homework' },
-  { href: '/tags/lesson', title: 'Lessons' },
+  // { href: '/tags/homework', title: 'Homework' },
+  { href: '/courses', title: 'Courses' },
   { href: '/tags', title: 'Tags' },
   //{ href: '/projects', title: 'Projects' },
   { href: '/about', title: 'Instructor' },

--- a/lib/courses.js
+++ b/lib/courses.js
@@ -1,0 +1,12 @@
+import fs from 'fs'
+import matter from 'gray-matter'
+import path from 'path'
+import { getSubdirectories } from './mdx'
+import kebabCase from './utils/kebabCase'
+
+const root = process.cwd()
+
+export async function getAllCourses(type) {
+  const courses = await getSubdirectories(type)
+  return courses
+}

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -4,7 +4,7 @@ import matter from 'gray-matter'
 import path from 'path'
 import readingTime from 'reading-time'
 import { visit } from 'unist-util-visit'
-import getAllFilesRecursively from './utils/files'
+import getAllFilesRecursively, { getAllSubdirectories } from './utils/files'
 // Remark packages
 import remarkGfm from 'remark-gfm'
 import remarkFootnotes from 'remark-footnotes'
@@ -28,6 +28,12 @@ export function getFiles(type) {
   const files = getAllFilesRecursively(prefixPaths)
   // Only want to return blog/path and ignore root, replace is needed to work on Windows
   return files.map((file) => file.slice(prefixPaths.length + 1).replace(/\\/g, '/'))
+}
+
+export function getSubdirectories(type) {
+  const prefixPaths = path.join(root, 'data', type)
+  const directories = getAllSubdirectories(prefixPaths)
+  return directories.map((directory) => directory.slice(prefixPaths.length + 1).replace(/\\/g, '/'))
 }
 
 export function formatSlug(slug) {

--- a/lib/utils/files.js
+++ b/lib/utils/files.js
@@ -20,4 +20,10 @@ const pathJoinPrefix = (prefix) => (extraPath) => path.join(prefix, extraPath)
 const getAllFilesRecursively = (folder) =>
   pipe(fs.readdirSync, map(pipe(pathJoinPrefix(folder), walkDir)), flattenArray)(folder)
 
+export const getAllSubdirectories = (folder) =>
+  fs
+    .readdirSync(folder)
+    .map((file) => path.join(folder, file))
+    .filter((fullPath) => fs.statSync(fullPath).isDirectory())
+
 export default getAllFilesRecursively

--- a/pages/courses.js
+++ b/pages/courses.js
@@ -1,0 +1,36 @@
+import Link from '@/components/Link'
+import { PageSEO } from '@/components/SEO'
+import Tag from '@/components/Tag'
+import siteMetadata from '@/data/siteMetadata'
+import { getAllCourses } from '@/lib/courses'
+import kebabCase from '@/lib/utils/kebabCase'
+
+export async function getStaticProps() {
+  const courses = await getAllCourses('blog')
+
+  return { props: { courses } }
+}
+
+export default function Courses({ courses }) {
+  return (
+    <>
+      <PageSEO title={`Tags - ${siteMetadata.author}`} description="Things I blog about" />
+      <div className="flex flex-col items-start justify-start divide-y divide-gray-200 dark:divide-gray-700 md:mt-24 md:flex-row md:items-center md:justify-center md:space-x-6 md:divide-y-0">
+        <div className="space-x-2 pt-6 pb-8 md:space-y-5">
+          <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:border-r-2 md:px-6 md:text-6xl md:leading-14">
+            Courses
+          </h1>
+        </div>
+        <div className="flex max-w-lg flex-wrap">
+          {courses.map((courseName) => {
+            return (
+              <div key={courseName} className="mt-2 mb-2 mr-5">
+                <Tag text={courseName} />
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
Added courses page that takes same structure as tags. 
Works by adding subdirectories to `data/blog/[subdirname]` and a corresponding tag with the same text as `subdirname` to any md pages belonging to the course.  

TODO: add summary of course to course page, get course files from directories instead of tags. 